### PR TITLE
Mark IC Boise, Lewiston, and also Sandpoint abandoned

### DIFF
--- a/groups.json
+++ b/groups.json
@@ -664,7 +664,8 @@
     "tla": "IC:Boise",
     "locality": "Boise",
     "url": "https://www.facebook.com/groups/icboise/",
-    "eventbriteOrganizerId": "16666208492"
+    "eventbriteOrganizerId": "16666208492",
+    "abandonedDate": "2020-01-01"
   },
   {
     "name": "Innovation Collective: Lewiston",
@@ -672,7 +673,8 @@
     "addedDate": "2018-01-01",
     "tla": "IC:Lewiston",
     "locality": "Lewiston",
-    "url": "https://www.facebook.com/groups/iclewiston/"
+    "url": "https://www.facebook.com/groups/iclewiston/",
+    "abandonedDate": "2020-01-01"
   },
   {
     "name": "Innovation Collective: Sandpoint",
@@ -680,7 +682,8 @@
     "addedDate": "2017-08-30",
     "tla": "IC:Sandpoint",
     "locality": "Sandpoint",
-    "url": "https://www.facebook.com/groups/icsandpoint/"
+    "url": "https://www.facebook.com/groups/icsandpoint/",
+    "abandonedDate": "2020-01-01"
   },
   {
     "name": "Interactive Artists and Animators Group of Idaho",


### PR DESCRIPTION
Decided to use 2020-01-01 as abandonedDate, since I did find a new story in early 2019 about IC:Sandpoint.

None of the Facebook groups have had new members or new posts in the last month (June 30 2020.) Facebook won't show anything of private group activity beyond that. I do think if these groups were healthy/active, they'd show up on the IC site itself.

Going forward, if an IC would like to be listed, please put in an issue here, and let's work out a way the community can be aware of events and opportunities beyond a Facebook group.