### PR TITLE
Add Future Ada, replacing Geek Girls Spokane

### DIFF
--- a/groups.json
+++ b/groups.json
@@ -506,13 +506,6 @@
     "locality": "Spokane",
     "url": "https://futureada.org/",
     "eventbriteOrganizerId": "future-ada-18080270116"
-  },    
-  {
-    "name": "Geek Girls Spokane",
-    "id": "2331308c-spokane-geek-girls",
-    "addedDate": "2013-01-01",
-    "locality": "Spokane",
-    "url": "https://www.facebook.com/spokanegeekgirls"
   },
   {
     "name": "Gemstate.io Events",

--- a/groups.json
+++ b/groups.json
@@ -500,6 +500,14 @@
     "abandonedDate": "2020-06-15"
   },
   {
+    "name": "Future Ada",
+    "id": "ac43a1d5-spokane-futureada",
+    "addedDate": "2020-10-13",
+    "locality": "Spokane",
+    "url": "https://futureada.org/",
+    "eventbriteOrganizerId": "future-ada-18080270116"
+  },    
+  {
     "name": "Geek Girls Spokane",
     "id": "2331308c-spokane-geek-girls",
     "addedDate": "2013-01-01",


### PR DESCRIPTION
This resolves #107. This adds Future Ada, replacing Geek Girls Spokane which never had a good site and only limited events.